### PR TITLE
Update Beaglebone Black instructions to use P9_17 and P9_18

### DIFF
--- a/examples/simpletest.py
+++ b/examples/simpletest.py
@@ -36,7 +36,11 @@ import SI1145.SI1145 as SI1145
 # on the Pi's revision.
 #
 # For the Beaglebone Black the library will assume bus 1 by default, which is
-# exposed with SCL = P9_19 and SDA = P9_20.
+# exposed with I2C1_SCL = P9_17 and I2C1_SDA = P9_18
+# Header pinout: http://beagleboard.org/static/images/cape-headers-i2c.png
+# Configure the pins for I2C with these pins:
+#   sudo config-pin p9.17 i2c
+#   sudo config-pin p9.18 i2c
 
 sensor = SI1145.SI1145()
 


### PR DESCRIPTION
Adafruit_GPIO.I2C assumes bus 1 by default.

For BeagleBone, use pin P9_17 (I2C1_SCL) and P9_18 (I2C1_SDA).  

Refer to the header pinout diagram:
http://beagleboard.org/static/images/cape-headers-i2c.png

Run these commands to configure those pins for I2C:
```
sudo config-pin p9.17 i2c
sudo config-pin p9.18 i2c
```

Further discussion is in this [Adafruit Forum discussion](https://forums.adafruit.com/viewtopic.php?f=49&t=111355&p=558518#p558518)